### PR TITLE
Fix typing and remove useless GameList serialization 

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Test typing with mypy
         run: |
-          mypy snat
+          mypy --strict snat
 
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.2.1]
 - Add documentation
+- Fix typing
 
 ## [0.2.0]
 - Add icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.2.1]
 - Add documentation
 - Fix typing
+- Remove useless serialisation with `pickle`
 
 ## [0.2.0]
 - Add icon

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.2.1]
 - Add documentation
 - Fix typing
-- Remove useless serialisation with `pickle`
+- Remove useless GameList serialisation with `pickle`
 
 ## [0.2.0]
 - Add icon

--- a/snat/__main__.py
+++ b/snat/__main__.py
@@ -53,7 +53,7 @@ def start_app() -> None:
     sys.exit(app.exec())
 
 
-def main():
+def main() -> None:
     """Main entry point of the application."""
     args = parse_args()
     configure_logging(args.debug)

--- a/snat/abstract_input_dialog.py
+++ b/snat/abstract_input_dialog.py
@@ -132,7 +132,7 @@ class AbstractRequestInputDialog(AbstractInputDialog):
         request = QtNetwork.QNetworkRequest(url)
         self.manager.get(request)
 
-    def handle_response(self, reply: QtNetwork.QNetworkReply):
+    def handle_response(self, reply: QtNetwork.QNetworkReply) -> None:
         """Handles the response from the request.
 
         Args:

--- a/snat/achievement_list.py
+++ b/snat/achievement_list.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any
 
-from PyQt6 import QtCore, QtGui, QtWidgets
+from PyQt6 import QtCore, QtGui, QtNetwork, QtWidgets
 
 from .game_list import Achievement, GameList
 from .steam_api import SteamApi
@@ -54,19 +54,25 @@ class AchievementWidget(QtWidgets.QListWidgetItem):
         else:
             steam_api.make_get_request(self.icon_url, self.handle_icon_response, self.handle_icon_error, True)
 
-    def handle_icon_response(self, icon: bytes, _) -> None:
+    def handle_icon_response(self, icon: bytes, other: None) -> None:
         """Load the icon from the response and add it to the cache
 
         Args:
             icon (bytes): Icon data
+            other (None): Unused
         """
         pixmap = QtGui.QPixmap()
         pixmap.loadFromData(icon)
         self.setIcon(QtGui.QIcon(pixmap))
         QtGui.QPixmapCache.insert(self.icon_url, pixmap)
 
-    def handle_icon_error(self, *_) -> None:
-        """Leave the icon empty"""
+    def handle_icon_error(self, error: QtNetwork.QNetworkReply.NetworkError, other: None) -> None:
+        """Leave the icon empty
+
+        Args:
+            error (QtNetwork.QNetworkReply.NetworkError): Network error
+            other (None): Unused
+        """
         logging.warning("Failed to load icon")
 
 
@@ -141,8 +147,13 @@ class AchievementList(QtWidgets.QListWidget):
                 achievements.append(game.schema[raw_achievement["apiname"]])
         self.add_achievements(achievements)
 
-    def handle_user_achiev_error(self, *_) -> None:
-        """Display an error message and disable the list"""
+    def handle_user_achiev_error(self, error: QtNetwork.QNetworkReply.NetworkError, other: None) -> None:
+        """Display an error message and disable the list
+
+        Args:
+            error (QtNetwork.QNetworkReply.NetworkError): Network error
+            other (None): Unused
+        """
         self.setEnabled(False)
         QtWidgets.QMessageBox.critical(self, "Error", "Failed to load achievements!\n"
                                        "(You can try to change the game)")

--- a/snat/settings.py
+++ b/snat/settings.py
@@ -1,5 +1,4 @@
 import logging
-from pickle import dumps, loads
 from string import Template
 
 from PyQt6 import QtCore, QtNetwork, QtWidgets
@@ -100,49 +99,58 @@ class Settings(QtCore.QSettings):
     @property
     def steam_api_key(self) -> str:
         """Loads the Steam API key from the settings"""
-        return self.value("steam_api_key")
+        value = self.value("steam_api_key", type=str)
+        if not isinstance(value, str):
+            raise TypeError("steam_api_key is not a string")
+        return value
 
     @property
     def steam_user_id(self) -> str:
         """Set the Steam user ID in the settings"""
-        return self.value("steam_user_id")
+        value = self.value("steam_user_id", type=str)
+        if not isinstance(value, str):
+            raise RuntimeError("steam_user_id is not a string")
+        return value
 
     @property
     def game_list_cache(self) -> GameList | None:
         """Loads the game list from the settings and deserializes it or returns None if it is not set"""
-        cache = self.value("schemes", None)
-        if cache is None:
+        value = self.value("schemes", type=bytes, defaultValue=None)
+        if value is None:
             return None
-
-        logging.info("Loading game list from cache")
-        try:
-            return loads(cache)
-        except Exception as exception:
-            logging.warning("Failed to load game list from cache", exc_info=exception)
-            return None
+        if not isinstance(value, dict):
+            raise TypeError("game_list is not a GameList")
+        return value
 
     @game_list_cache.setter
     def game_list_cache(self, value: GameList) -> None:
         """Serializes the game list and stores it in the settings"""
-        self.setValue("schemes", dumps(value))
+        self.setValue("schemes", value)
 
     @property
     def selected_game(self) -> int | None:
         """Loads the selected game from the settings or returns None if it is not set"""
-        value = self.value("selected_game", None)
+        value = self.value("selected_game", None, type=int)
         if value is None:
             return None
-        return int(value)
+        if not isinstance(value, int):
+            raise TypeError("selected_game is not an int")
+        return value
 
     @selected_game.setter
     def selected_game(self, value: int) -> None:
         """Sets the selected game in the settings"""
-        self.setValue("selected_game", str(value))
+        self.setValue("selected_game", value)
 
     @property
     def position(self) -> QtCore.QPoint | None:
         """Loads the window position from the settings or returns None if it is not set"""
-        return self.value("position", None)
+        value = self.value("position", None, type=QtCore.QPoint)
+        if value is None:
+            return None
+        if not isinstance(value, QtCore.QPoint):
+            raise TypeError("position is not a QPoint")
+        return value
 
     @position.setter
     def position(self, value: QtCore.QPoint) -> None:
@@ -152,7 +160,12 @@ class Settings(QtCore.QSettings):
     @property
     def size(self) -> QtCore.QSize | None:
         """Loads the window size from the settings or returns None if it is not set"""
-        return self.value("size", None)
+        value = self.value("size", None, type=QtCore.QSize)
+        if value is None:
+            return None
+        if not isinstance(value, QtCore.QSize):
+            raise TypeError("size is not a QSize")
+        return value
 
     @size.setter
     def size(self, value: QtCore.QSize) -> None:

--- a/snat/settings.py
+++ b/snat/settings.py
@@ -98,7 +98,14 @@ class Settings(QtCore.QSettings):
 
     @property
     def steam_api_key(self) -> str:
-        """Loads the Steam API key from the settings"""
+        """Loads the Steam API key from the settings
+
+        Raises:
+            TypeError: If the value is not a string
+
+        Returns:
+            str: Steam API key
+        """
         value = self.value("steam_api_key", type=str)
         if not isinstance(value, str):
             raise TypeError("steam_api_key is not a string")
@@ -106,7 +113,14 @@ class Settings(QtCore.QSettings):
 
     @property
     def steam_user_id(self) -> str:
-        """Set the Steam user ID in the settings"""
+        """Set the Steam user ID in the settings
+
+        Raises:
+            RuntimeError: If the value is not a string
+
+        Returns:
+            str: Steam user ID
+        """
         value = self.value("steam_user_id", type=str)
         if not isinstance(value, str):
             raise RuntimeError("steam_user_id is not a string")
@@ -114,7 +128,14 @@ class Settings(QtCore.QSettings):
 
     @property
     def game_list_cache(self) -> GameList | None:
-        """Loads the game list from the settings and deserializes it or returns None if it is not set"""
+        """Loads the game list from the settings or returns None if it is not set
+
+        Raises:
+            TypeError: If the value is not a dict
+
+        Returns:
+            GameList | None: Game list or None if it is not set
+        """
         value = self.value("schemes", type=bytes, defaultValue=None)
         if value is None:
             return None
@@ -124,12 +145,23 @@ class Settings(QtCore.QSettings):
 
     @game_list_cache.setter
     def game_list_cache(self, value: GameList) -> None:
-        """Serializes the game list and stores it in the settings"""
+        """Sets the game list in the settings
+
+        Args:
+            value (GameList): Game list to serialize
+        """
         self.setValue("schemes", value)
 
     @property
     def selected_game(self) -> int | None:
-        """Loads the selected game from the settings or returns None if it is not set"""
+        """Loads the selected game from the settings or returns None if it is not set
+
+        Raises:
+            TypeError: If the value is not an int
+
+        Returns:
+            int | None: Selected game or None if it is not set
+        """
         value = self.value("selected_game", None, type=int)
         if value is None:
             return None
@@ -139,12 +171,23 @@ class Settings(QtCore.QSettings):
 
     @selected_game.setter
     def selected_game(self, value: int) -> None:
-        """Sets the selected game in the settings"""
+        """Sets the selected game in the settings
+
+        Args:
+            value (int): Selected game
+        """
         self.setValue("selected_game", value)
 
     @property
     def position(self) -> QtCore.QPoint | None:
-        """Loads the window position from the settings or returns None if it is not set"""
+        """Loads the window position from the settings or returns None if it is not set
+
+        Raises:
+            TypeError: If the value is not a QPoint
+
+        Returns:
+            QtCore.QPoint | None: Window position or None if it is not set
+        """
         value = self.value("position", None, type=QtCore.QPoint)
         if value is None:
             return None
@@ -154,12 +197,23 @@ class Settings(QtCore.QSettings):
 
     @position.setter
     def position(self, value: QtCore.QPoint) -> None:
-        """Sets the window position in the settings"""
+        """Sets the window position in the settings
+
+        Args:
+            value (QtCore.QPoint): Window position
+        """
         self.setValue("position", value)
 
     @property
     def size(self) -> QtCore.QSize | None:
-        """Loads the window size from the settings or returns None if it is not set"""
+        """Loads the window size from the settings or returns None if it is not set
+
+        Raises:
+            TypeError: If the value is not a QSize
+
+        Returns:
+            QtCore.QSize | None: Window size or None if it is not set
+        """
         value = self.value("size", None, type=QtCore.QSize)
         if value is None:
             return None
@@ -169,5 +223,9 @@ class Settings(QtCore.QSettings):
 
     @size.setter
     def size(self, value: QtCore.QSize) -> None:
-        """Sets the window size in the settings"""
+        """Sets the window size in the settings
+
+        Args:
+            value (QtCore.QSize): Window size
+        """
         self.setValue("size", value)

--- a/snat/settings.py
+++ b/snat/settings.py
@@ -136,7 +136,7 @@ class Settings(QtCore.QSettings):
         Returns:
             GameList | None: Game list or None if it is not set
         """
-        value = self.value("schemes", type=bytes, defaultValue=None)
+        value = self.value("schemes", type=dict, defaultValue=None)
         if value is None:
             return None
         if not isinstance(value, dict):

--- a/snat/steam_api.py
+++ b/snat/steam_api.py
@@ -72,7 +72,7 @@ class SteamApi:
             raise Exception("Network error")
         self.requests[reply] = RequestData(func, error, raw, other)
 
-    def handle_response(self, reply: QtNetwork.QNetworkReply):
+    def handle_response(self, reply: QtNetwork.QNetworkReply) -> None:
         """Process the response and call the appropriate functions
 
         Args:


### PR DESCRIPTION
- Fixed typing error showed by `mypy --strict`
- Add `--strict` to `mypy` in type-check job in publish workflow
- Remove useless GameList serialization with pickle (Qt manage this on it's own)